### PR TITLE
Update Go version to fix installation

### DIFF
--- a/amnezia-wireguard/Dockerfile
+++ b/amnezia-wireguard/Dockerfile
@@ -19,7 +19,7 @@ RUN \
         git=2.45.2-r0 \
     \
     && apk add --no-cache \
-        go=1.22.9-r0 \
+        go=1.22.10-r0 \
         iptables=1.8.10-r3 \
         libqrencode-tools=4.1.1-r2 \
         openresolv=3.13.2-r0 \

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,3 +1,3 @@
-name: Amnezia-WG addon for Home Assistan
+name: Amnezia-WG addon for Home Assistant
 url: 'https://github.com/yury-sannikov/addon-amnezia-wireguard'
 maintainer: Yuriy Sannikov


### PR DESCRIPTION
# Proposed Changes

It fails to install because `1.22.9-r0` conflicts with version installed in base image.
